### PR TITLE
Add middleware-protected routes with cookie-backed auth sessions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,46 @@
 This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
 
+## Auth flow & protected routes
+
+Authentication uses a **dual-storage strategy**:
+
+- **`localStorage`** (`auth_token`) — used by the browser API client to attach `Authorization: Bearer <token>` headers.
+- **`auth_token` cookie** — mirrored on login/logout so Next.js middleware can read the session on the edge without `localStorage` (which is unavailable in middleware).
+
+After a successful login, `api.setToken()` writes to both stores. `api.clearToken()` removes both.
+
+### Protected routes
+
+`src/middleware.ts` guards routes under `/dashboard/*` and `/profile/*`. Unauthenticated visitors are redirected to:
+
+```
+/login?redirect=/original-path
+```
+
+The login page reads `redirect` and sends the user to that path after sign-in (default: `/dashboard`).
+
+### Public routes
+
+These paths are reachable without a token:
+
+- `/`
+- `/login`
+- `/signup`
+
+Authenticated users who visit `/login` or `/signup` are redirected to `/dashboard`.
+
+### Session helpers
+
+`src/lib/auth/session.ts` exports:
+
+- `getTokenFromRequest(request)` / `isAuthenticatedFromRequest(request)` — for middleware
+- `setAuthCookie()` / `clearAuthCookie()` — client-side cookie sync
+
+`src/lib/auth/session.server.ts` exports:
+
+- `getToken()` — async, for Server Components (`cookies()`)
+- `isAuthenticated()`
+
 ## Getting Started
 
 First, run the development server:

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -1,0 +1,7 @@
+export default function DashboardPage() {
+  return (
+    <main className="min-h-screen flex items-center justify-center p-8">
+      <h1 className="text-2xl font-semibold">Dashboard</h1>
+    </main>
+  );
+}

--- a/src/app/(dashboard)/profile/page.tsx
+++ b/src/app/(dashboard)/profile/page.tsx
@@ -1,0 +1,7 @@
+export default function ProfilePage() {
+  return (
+    <main className="min-h-screen flex items-center justify-center p-8">
+      <h1 className="text-2xl font-semibold">Profile</h1>
+    </main>
+  );
+}

--- a/src/app/login/login-form.tsx
+++ b/src/app/login/login-form.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { FormEvent, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { api } from "@/lib/api/client";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type { AuthResponse } from "@/types/api";
+
+export function LoginForm() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const redirectTo = searchParams.get("redirect") || "/dashboard";
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError(null);
+    setIsSubmitting(true);
+
+    try {
+      const response = await api.post<AuthResponse>("/auth/login", {
+        email,
+        password,
+      });
+      api.setToken(response.access_token);
+      router.replace(redirectTo);
+    } catch {
+      setError("Login failed. Check your credentials and try again.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <main className="min-h-screen flex items-center justify-center p-8">
+      <form
+        onSubmit={handleSubmit}
+        className="w-full max-w-md space-y-4 rounded-lg border p-6"
+      >
+        <h1 className="text-2xl font-semibold">Log in</h1>
+
+        <div className="space-y-2">
+          <Label htmlFor="email">Email</Label>
+          <Input
+            id="email"
+            type="email"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            required
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="password">Password</Label>
+          <Input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            required
+          />
+        </div>
+
+        {error ? <p className="text-sm text-red-600">{error}</p> : null}
+
+        <Button type="submit" disabled={isSubmitting} className="w-full">
+          {isSubmitting ? "Signing in..." : "Sign in"}
+        </Button>
+      </form>
+    </main>
+  );
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,16 @@
+import { Suspense } from "react";
+import { LoginForm } from "./login-form";
+
+export default function LoginPage() {
+  return (
+    <Suspense
+      fallback={
+        <main className="min-h-screen flex items-center justify-center p-8">
+          <p>Loading...</p>
+        </main>
+      }
+    >
+      <LoginForm />
+    </Suspense>
+  );
+}

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,0 +1,7 @@
+export default function SignupPage() {
+  return (
+    <main className="min-h-screen flex items-center justify-center p-8">
+      <h1 className="text-2xl font-semibold">Sign up</h1>
+    </main>
+  );
+}

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -1,12 +1,16 @@
+import {
+  AUTH_TOKEN_COOKIE,
+  clearAuthCookie,
+  setAuthCookie,
+} from "@/lib/auth/session";
 import { ApiError, NetworkError } from "./errors";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3000";
-const TOKEN_KEY = "auth_token";
 
 function getToken(): string | null {
   if (typeof window === "undefined") return null;
   try {
-    return localStorage.getItem(TOKEN_KEY);
+    return localStorage.getItem(AUTH_TOKEN_COOKIE);
   } catch {
     return null;
   }
@@ -15,7 +19,8 @@ function getToken(): string | null {
 function setToken(token: string): void {
   if (typeof window === "undefined") return;
   try {
-    localStorage.setItem(TOKEN_KEY, token);
+    localStorage.setItem(AUTH_TOKEN_COOKIE, token);
+    setAuthCookie(token);
   } catch {
     console.error("Failed to store token");
   }
@@ -24,7 +29,8 @@ function setToken(token: string): void {
 function clearToken(): void {
   if (typeof window === "undefined") return;
   try {
-    localStorage.removeItem(TOKEN_KEY);
+    localStorage.removeItem(AUTH_TOKEN_COOKIE);
+    clearAuthCookie();
   } catch {
     console.error("Failed to clear token");
   }

--- a/src/lib/auth/constants.ts
+++ b/src/lib/auth/constants.ts
@@ -1,0 +1,3 @@
+export const AUTH_TOKEN_COOKIE = "auth_token";
+
+export const COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 7;

--- a/src/lib/auth/session.server.ts
+++ b/src/lib/auth/session.server.ts
@@ -1,0 +1,12 @@
+import { cookies } from "next/headers";
+import { AUTH_TOKEN_COOKIE } from "./constants";
+
+export async function getToken(): Promise<string | null> {
+  const cookieStore = await cookies();
+  return cookieStore.get(AUTH_TOKEN_COOKIE)?.value ?? null;
+}
+
+export async function isAuthenticated(): Promise<boolean> {
+  const token = await getToken();
+  return Boolean(token);
+}

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -1,0 +1,28 @@
+import type { NextRequest } from "next/server";
+import { AUTH_TOKEN_COOKIE, COOKIE_MAX_AGE_SECONDS } from "./constants";
+
+export { AUTH_TOKEN_COOKIE } from "./constants";
+
+export function getTokenFromRequest(request: NextRequest): string | null {
+  return request.cookies.get(AUTH_TOKEN_COOKIE)?.value ?? null;
+}
+
+export function isAuthenticatedFromRequest(request: NextRequest): boolean {
+  return Boolean(getTokenFromRequest(request));
+}
+
+export function setAuthCookie(token: string): void {
+  if (typeof document === "undefined") return;
+
+  const secure =
+    typeof window !== "undefined" && window.location.protocol === "https:"
+      ? "; Secure"
+      : "";
+
+  document.cookie = `${AUTH_TOKEN_COOKIE}=${encodeURIComponent(token)}; path=/; max-age=${COOKIE_MAX_AGE_SECONDS}; SameSite=Lax${secure}`;
+}
+
+export function clearAuthCookie(): void {
+  if (typeof document === "undefined") return;
+  document.cookie = `${AUTH_TOKEN_COOKIE}=; path=/; max-age=0`;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { isAuthenticatedFromRequest } from "@/lib/auth/session";
+
+const AUTH_ROUTES = ["/login", "/signup"];
+const PROTECTED_PREFIXES = ["/dashboard", "/profile"];
+
+function isProtectedPath(pathname: string): boolean {
+  return PROTECTED_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`)
+  );
+}
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+  const authenticated = isAuthenticatedFromRequest(request);
+
+  if (authenticated && AUTH_ROUTES.includes(pathname)) {
+    return NextResponse.redirect(new URL("/dashboard", request.url));
+  }
+
+  if (!authenticated && isProtectedPath(pathname)) {
+    const loginUrl = new URL("/login", request.url);
+    loginUrl.searchParams.set("redirect", pathname);
+    return NextResponse.redirect(loginUrl);
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: [
+    "/login",
+    "/signup",
+    "/dashboard/:path*",
+    "/profile/:path*",
+  ],
+};


### PR DESCRIPTION
## Summary

Adds Next.js middleware to protect authenticated routes (`/dashboard`, `/profile`) and redirects unauthenticated users to `/login` with a `redirect` query param. Auth tokens are mirrored to a cookie so middleware can read sessions on the edge, while `localStorage` continues to power API `Authorization` headers.

## Changes

- **`src/middleware.ts`** — guards `/dashboard/*` and `/profile/*`; redirects unauthenticated users to `/login?redirect=<path>`; redirects authenticated users away from `/login` and `/signup`
- **`src/lib/auth/session.ts`** — `getTokenFromRequest`, `isAuthenticatedFromRequest`, and client cookie sync helpers
- **`src/lib/auth/session.server.ts`** — async `getToken()` / `isAuthenticated()` for Server Components
- **`src/lib/api/client.ts`** — `setToken()` / `clearToken()` now sync `auth_token` to both `localStorage` and cookie
- **Route pages** — `(dashboard)/dashboard`, `(dashboard)/profile`, `login` (with redirect-after-login), `signup`
- **`README.md`** — documents auth flow and protected routes

## Auth strategy

| Store | Purpose |
|-------|---------|
| `localStorage` (`auth_token`) | API client `Authorization: Bearer` header |
| `auth_token` cookie | Middleware / server session checks |

Middleware cannot access `localStorage`, so both stores are kept in sync on login/logout.

## Acceptance criteria

- [x] Unauthenticated access to `/dashboard` redirects to login
- [x] `redirect` query param returns user to intended page after login
- [x] Public pages (`/`, `/login`, `/signup`) remain accessible without a token
- [x] Middleware runs without errors in `next dev` and `next build`
- [x] No infinite redirect loops

closes #6 