### PR TITLE
feature:Build App Shell with Sidebar and Top Navigation

### DIFF
--- a/src/app/(dashboard)/home/page.tsx
+++ b/src/app/(dashboard)/home/page.tsx
@@ -1,0 +1,12 @@
+export default function HomePage() {
+  return (
+    <main className="min-h-[60vh] flex items-center justify-center p-8 text-center">
+      <div>
+        <h1 className="text-3xl font-semibold">Home</h1>
+        <p className="mt-3 max-w-xl text-sm text-muted-foreground">
+          This is a placeholder page for the Home route. The dashboard shell is active for this layout and reflects the current navigation state.
+        </p>
+      </div>
+    </main>
+  )
+}

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next"
+import DashboardShell from "@/components/navigation/DashboardShell"
+
+export const metadata: Metadata = {
+  title: "MyFans Dashboard",
+  description: "Dashboard shell for MyFans with responsive sidebar and top navigation.",
+}
+
+export default function DashboardLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode
+}>) {
+  return <DashboardShell>{children}</DashboardShell>
+}

--- a/src/components/navigation/DashboardShell.tsx
+++ b/src/components/navigation/DashboardShell.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import { useCallback, useState } from "react"
+import Sidebar from "@/components/navigation/Sidebar"
+import TopNav from "@/components/navigation/TopNav"
+
+interface DashboardShellProps {
+  children: React.ReactNode
+}
+
+export default function DashboardShell({ children }: DashboardShellProps) {
+  const [sidebarOpen, setSidebarOpen] = useState(false)
+
+  const handleOpen = useCallback(() => setSidebarOpen(true), [])
+  const handleClose = useCallback(() => setSidebarOpen(false), [])
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <Sidebar open={sidebarOpen} onClose={handleClose} />
+      <div className="md:ml-72">
+        <TopNav onOpenSidebar={handleOpen} />
+        <main className="min-h-[calc(100vh-4rem)] p-4 sm:p-6 lg:p-8">
+          <div className="mx-auto max-w-7xl rounded-3xl border border-border bg-card p-6 shadow-sm sm:p-8">
+            {children}
+          </div>
+        </main>
+      </div>
+    </div>
+  )
+}

--- a/src/components/navigation/Sidebar.tsx
+++ b/src/components/navigation/Sidebar.tsx
@@ -1,0 +1,94 @@
+"use client"
+
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+import { Home, LayoutDashboard, Settings2, User, X } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+const navItems = [
+  { label: "Home", href: "/home", icon: Home },
+  { label: "Dashboard", href: "/dashboard", icon: LayoutDashboard },
+  { label: "Profile", href: "/profile", icon: User },
+  { label: "Settings", href: "/settings", icon: Settings2 },
+]
+
+interface SidebarProps {
+  open: boolean
+  onClose: () => void
+}
+
+export default function Sidebar({ open, onClose }: SidebarProps) {
+  const pathname = usePathname()
+
+  return (
+    <>
+      <aside
+        className={cn(
+          "fixed inset-y-0 left-0 z-30 w-72 transform border-r border-sidebar-border bg-sidebar text-sidebar-foreground transition-transform duration-200 ease-in-out md:static md:translate-x-0",
+          open ? "translate-x-0" : "-translate-x-full"
+        )}
+        aria-label="Primary navigation"
+      >
+        <div className="flex h-full flex-col">
+          <div className="flex items-center justify-between gap-3 border-b border-sidebar-border px-6 py-5">
+            <div>
+              <p className="text-lg font-semibold text-sidebar-primary">MyFans</p>
+              <p className="text-sm text-sidebar-accent-foreground">Creator workspace</p>
+            </div>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={onClose}
+              className="md:hidden"
+              aria-label="Close navigation"
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
+
+          <nav className="flex-1 space-y-1 p-4" aria-label="Dashboard links">
+            {navItems.map((item) => {
+              const isActive = pathname === item.href
+              const Icon = item.icon
+
+              return (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  className={cn(
+                    "flex items-center gap-3 rounded-xl px-4 py-3 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-primary focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar",
+                    isActive
+                      ? "bg-sidebar-primary text-sidebar-primary-foreground shadow-sm"
+                      : "text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+                  )}
+                  aria-current={isActive ? "page" : undefined}
+                  onClick={onClose}
+                >
+                  <Icon className="h-5 w-5" aria-hidden="true" />
+                  {item.label}
+                </Link>
+              )
+            })}
+          </nav>
+
+          <div className="border-t border-sidebar-border p-4 text-sm text-sidebar-accent-foreground">
+            <p className="font-medium">MyFans Shell</p>
+            <p className="mt-2 text-xs leading-5">
+              Use the sidebar to navigate between feature screens. Mobile users can open and close the menu with the top nav button.
+            </p>
+          </div>
+        </div>
+      </aside>
+
+      {open && (
+        <button
+          type="button"
+          className="fixed inset-0 z-20 bg-black/40 md:hidden"
+          onClick={onClose}
+          aria-label="Close sidebar overlay"
+        />
+      )}
+    </>
+  )
+}

--- a/src/components/navigation/TopNav.tsx
+++ b/src/components/navigation/TopNav.tsx
@@ -1,0 +1,50 @@
+"use client"
+
+import { Bell, Menu, UserCircle } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+interface TopNavProps {
+  onOpenSidebar: () => void
+}
+
+export default function TopNav({ onOpenSidebar }: TopNavProps) {
+  return (
+    <header className="sticky top-0 z-10 border-b border-sidebar-border bg-background/95 backdrop-blur md:pl-72">
+      <div className="flex h-16 items-center justify-between gap-3 px-4 sm:px-6">
+        <div className="flex items-center gap-2">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="md:hidden"
+            onClick={onOpenSidebar}
+            aria-label="Open navigation menu"
+          >
+            <Menu className="h-5 w-5" />
+          </Button>
+
+          <div className="flex items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-primary text-primary-foreground">
+              MF
+            </div>
+            <div className="hidden sm:block">
+              <p className="text-sm font-semibold">MyFans</p>
+              <p className="text-xs text-muted-foreground">App shell</p>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Button variant="outline" size="sm">
+            New
+          </Button>
+          <Button variant="ghost" size="icon" aria-label="Notifications">
+            <Bell className="h-5 w-5" />
+          </Button>
+          <Button variant="ghost" size="icon" aria-label="Account">
+            <UserCircle className="h-5 w-5" />
+          </Button>
+        </div>
+      </div>
+    </header>
+  )
+}


### PR DESCRIPTION
closes #3

Description
Task: Build App Shell with Sidebar and Top Navigation
Overview
The frontend is currently a single demo page with UI primitives. We need a reusable app shell (sidebar, top bar, main content area) that future feature pages can plug into — without building every screen yet.

Goals
Create app/(dashboard)/layout.tsx with responsive sidebar + header
Add navigation links: Home, Dashboard, Profile, Settings (routes can 404 for now)
Mobile: collapsible sidebar or bottom nav placeholder
Use existing shadcn Button and Tailwind tokens from globals.css
Match MyFans branding (logo placeholder, primary color)
Deliverables
components/navigation/Sidebar.tsx and TopNav.tsx
Dashboard layout wrapping child routes
Active link highlighting based on current pathname
Basic Storybook-style screenshot or README snippet showing the shell
Acceptance Criteria
Shell renders on all (dashboard) routes
Sidebar collapses gracefully on viewports < 768px
Navigation is keyboard accessible (tab order, aria labels)
No API calls required — static shell only
Lint and build pass (npm run build)