### PR TITLE
Add creator post composer UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "next": "15.3.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "tailwind-merge": "^3.2.0"
+        "tailwind-merge": "^3.2.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -5970,6 +5971,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "next": "15.3.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "tailwind-merge": "^3.2.0"
+    "tailwind-merge": "^3.2.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/(dashboard)/dashboard/posts/new/page.tsx
+++ b/src/app/(dashboard)/dashboard/posts/new/page.tsx
@@ -1,0 +1,10 @@
+import { CreatorGuard } from "@/components/auth/creator-guard";
+import { PostComposer } from "@/components/posts/PostComposer";
+
+export default function NewPostPage() {
+  return (
+    <CreatorGuard>
+      <PostComposer />
+    </CreatorGuard>
+  );
+}

--- a/src/app/(dashboard)/dashboard/posts/page.tsx
+++ b/src/app/(dashboard)/dashboard/posts/page.tsx
@@ -1,0 +1,19 @@
+import { Suspense } from "react";
+import { CreatorGuard } from "@/components/auth/creator-guard";
+import { PostList } from "@/components/posts/PostList";
+
+export default function PostsPage() {
+  return (
+    <CreatorGuard>
+      <Suspense
+        fallback={
+          <main className="min-h-screen p-8">
+            <p>Loading...</p>
+          </main>
+        }
+      >
+        <PostList />
+      </Suspense>
+    </CreatorGuard>
+  );
+}

--- a/src/app/login/login-form.tsx
+++ b/src/app/login/login-form.tsx
@@ -28,6 +28,7 @@ export function LoginForm() {
         password,
       });
       api.setToken(response.access_token);
+      api.setCurrentUser(response.user);
       router.replace(redirectTo);
     } catch {
       setError("Login failed. Check your credentials and try again.");

--- a/src/components/auth/creator-guard.tsx
+++ b/src/components/auth/creator-guard.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { api } from "@/lib/api/client";
+
+export function CreatorGuard({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+  const [allowed, setAllowed] = useState(false);
+
+  useEffect(() => {
+    const user = api.getCurrentUser();
+
+    if (!user || user.role !== "creator") {
+      router.replace("/dashboard");
+      return;
+    }
+
+    setAllowed(true);
+  }, [router]);
+
+  if (!allowed) return null;
+
+  return <>{children}</>;
+}

--- a/src/components/posts/PostComposer.tsx
+++ b/src/components/posts/PostComposer.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { FormEvent, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+import {
+  createPostSchema,
+  POST_BODY_MAX_LENGTH,
+  POST_TITLE_MAX_LENGTH,
+  type PostVisibility,
+} from "@/lib/validations/post";
+import { createPost } from "@/lib/api/posts";
+
+const VISIBILITY_OPTIONS: { value: PostVisibility; label: string }[] = [
+  { value: "public", label: "Public" },
+  { value: "subscribers", label: "Subscribers only" },
+];
+
+export function PostComposer() {
+  const router = useRouter();
+  const [title, setTitle] = useState("");
+  const [body, setBody] = useState("");
+  const [mediaUrl, setMediaUrl] = useState("");
+  const [visibility, setVisibility] = useState<PostVisibility>("public");
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setSubmitError(null);
+
+    const result = createPostSchema.safeParse({
+      title,
+      body,
+      visibility,
+      mediaUrl,
+    });
+
+    if (!result.success) {
+      const fieldErrors: Record<string, string> = {};
+      for (const issue of result.error.issues) {
+        const key = issue.path[0];
+        if (typeof key === "string" && !fieldErrors[key]) {
+          fieldErrors[key] = issue.message;
+        }
+      }
+      setErrors(fieldErrors);
+      return;
+    }
+
+    setErrors({});
+    setIsSubmitting(true);
+
+    try {
+      await createPost(result.data);
+      router.push("/dashboard/posts?published=1");
+    } catch {
+      setSubmitError("Failed to publish post. Please try again.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <main className="min-h-screen p-8">
+      <form
+        onSubmit={handleSubmit}
+        className="mx-auto w-full max-w-2xl space-y-6"
+      >
+        <h1 className="text-2xl font-semibold">New post</h1>
+
+        <div className="space-y-2">
+          <Label htmlFor="title">Title</Label>
+          <Input
+            id="title"
+            value={title}
+            onChange={(event) => setTitle(event.target.value)}
+            maxLength={POST_TITLE_MAX_LENGTH}
+            aria-invalid={Boolean(errors.title)}
+          />
+          <div className="flex items-center justify-between text-xs text-muted-foreground">
+            <span className="text-red-600">{errors.title}</span>
+            <span>
+              {title.length}/{POST_TITLE_MAX_LENGTH}
+            </span>
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="body">Body</Label>
+          <Textarea
+            id="body"
+            value={body}
+            onChange={(event) => setBody(event.target.value)}
+            maxLength={POST_BODY_MAX_LENGTH}
+            rows={8}
+            aria-invalid={Boolean(errors.body)}
+          />
+          <div className="flex items-center justify-between text-xs text-muted-foreground">
+            <span className="text-red-600">{errors.body}</span>
+            <span>
+              {body.length}/{POST_BODY_MAX_LENGTH}
+            </span>
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="mediaUrl">Media URL (optional)</Label>
+          <Input
+            id="mediaUrl"
+            type="url"
+            value={mediaUrl}
+            onChange={(event) => setMediaUrl(event.target.value)}
+            placeholder="https://..."
+            aria-invalid={Boolean(errors.mediaUrl)}
+          />
+          {errors.mediaUrl ? (
+            <p className="text-xs text-red-600">{errors.mediaUrl}</p>
+          ) : null}
+        </div>
+
+        <div className="space-y-2">
+          <Label>Visibility</Label>
+          <div className="flex gap-2">
+            {VISIBILITY_OPTIONS.map((option) => (
+              <button
+                key={option.value}
+                type="button"
+                onClick={() => setVisibility(option.value)}
+                className={cn(
+                  "rounded-md border px-3 py-1.5 text-sm font-medium transition-colors",
+                  visibility === option.value
+                    ? "border-primary bg-primary text-primary-foreground"
+                    : "border-input bg-background hover:bg-accent"
+                )}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {submitError ? (
+          <p className="text-sm text-red-600">{submitError}</p>
+        ) : null}
+
+        <Button type="submit" disabled={isSubmitting}>
+          {isSubmitting ? "Publishing..." : "Publish"}
+        </Button>
+      </form>
+    </main>
+  );
+}

--- a/src/components/posts/PostList.tsx
+++ b/src/components/posts/PostList.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { listPosts } from "@/lib/api/posts";
+import type { Post } from "@/types/api";
+
+function formatDate(value: string): string {
+  return new Date(value).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+export function PostList() {
+  const searchParams = useSearchParams();
+  const [posts, setPosts] = useState<Post[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [showSuccessToast, setShowSuccessToast] = useState(
+    searchParams.get("published") === "1"
+  );
+
+  useEffect(() => {
+    let isMounted = true;
+
+    listPosts()
+      .then((data) => {
+        if (isMounted) setPosts(data);
+      })
+      .catch(() => {
+        if (isMounted) setError("Failed to load posts.");
+      })
+      .finally(() => {
+        if (isMounted) setIsLoading(false);
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!showSuccessToast) return;
+    const timeout = setTimeout(() => setShowSuccessToast(false), 4000);
+    return () => clearTimeout(timeout);
+  }, [showSuccessToast]);
+
+  return (
+    <main className="min-h-screen p-8">
+      <div className="mx-auto w-full max-w-2xl space-y-6">
+        {showSuccessToast ? (
+          <div className="rounded-md border border-green-600 bg-green-50 px-4 py-3 text-sm text-green-800">
+            Post published successfully.
+          </div>
+        ) : null}
+
+        <div className="flex items-center justify-between">
+          <h1 className="text-2xl font-semibold">Posts</h1>
+          <Link href="/dashboard/posts/new">
+            <Button>New post</Button>
+          </Link>
+        </div>
+
+        {isLoading ? (
+          <p className="text-sm text-muted-foreground">Loading...</p>
+        ) : null}
+        {error ? <p className="text-sm text-red-600">{error}</p> : null}
+
+        {!isLoading && !error && posts.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No posts yet.</p>
+        ) : null}
+
+        <ul className="space-y-4">
+          {posts.map((post) => (
+            <li key={post.id} className="rounded-lg border p-4">
+              <div className="flex items-center justify-between gap-2">
+                <h2 className="font-medium">{post.title}</h2>
+                <Badge
+                  variant={post.visibility === "public" ? "default" : "secondary"}
+                >
+                  {post.visibility === "public" ? "Public" : "Subscribers"}
+                </Badge>
+              </div>
+              <p className="mt-1 text-sm text-muted-foreground">
+                {formatDate(post.createdAt)}
+              </p>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </main>
+  );
+}

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,36 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium transition-colors",
+  {
+    variants: {
+      variant: {
+        default: "border-transparent bg-primary text-primary-foreground",
+        secondary: "border-transparent bg-secondary text-secondary-foreground",
+        outline: "text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Badge({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<"span"> & VariantProps<typeof badgeVariants>) {
+  return (
+    <span
+      data-slot="badge"
+      className={cn(badgeVariants({ variant, className }))}
+      {...props}
+    />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -4,8 +4,10 @@ import {
   setAuthCookie,
 } from "@/lib/auth/session";
 import { ApiError, NetworkError } from "./errors";
+import type { User } from "@/types/api";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3000";
+const CURRENT_USER_STORAGE_KEY = "auth_user";
 
 function getToken(): string | null {
   if (typeof window === "undefined") return null;
@@ -33,6 +35,34 @@ function clearToken(): void {
     clearAuthCookie();
   } catch {
     console.error("Failed to clear token");
+  }
+}
+
+function getCurrentUser(): User | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = localStorage.getItem(CURRENT_USER_STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as User) : null;
+  } catch {
+    return null;
+  }
+}
+
+function setCurrentUser(user: User): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(CURRENT_USER_STORAGE_KEY, JSON.stringify(user));
+  } catch {
+    console.error("Failed to store current user");
+  }
+}
+
+function clearCurrentUser(): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.removeItem(CURRENT_USER_STORAGE_KEY);
+  } catch {
+    console.error("Failed to clear current user");
   }
 }
 
@@ -119,4 +149,7 @@ export const api = {
   setToken,
   clearToken,
   getToken,
+  getCurrentUser,
+  setCurrentUser,
+  clearCurrentUser,
 };

--- a/src/lib/api/posts.ts
+++ b/src/lib/api/posts.ts
@@ -1,0 +1,16 @@
+import { api } from "@/lib/api/client";
+import type { CreatePostInput } from "@/lib/validations/post";
+import type { Post } from "@/types/api";
+
+export function createPost(input: CreatePostInput): Promise<Post> {
+  return api.post<Post>("/posts", {
+    title: input.title,
+    body: input.body,
+    visibility: input.visibility,
+    mediaUrl: input.mediaUrl || undefined,
+  });
+}
+
+export function listPosts(): Promise<Post[]> {
+  return api.get<Post[]>("/posts");
+}

--- a/src/lib/validations/post.ts
+++ b/src/lib/validations/post.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+
+export const POST_TITLE_MAX_LENGTH = 120;
+export const POST_BODY_MAX_LENGTH = 5000;
+
+export const postVisibilitySchema = z.enum(["public", "subscribers"]);
+
+export const createPostSchema = z.object({
+  title: z
+    .string()
+    .trim()
+    .min(1, "Title is required")
+    .max(
+      POST_TITLE_MAX_LENGTH,
+      `Title must be ${POST_TITLE_MAX_LENGTH} characters or fewer`
+    ),
+  body: z
+    .string()
+    .trim()
+    .min(1, "Body is required")
+    .max(
+      POST_BODY_MAX_LENGTH,
+      `Body must be ${POST_BODY_MAX_LENGTH} characters or fewer`
+    ),
+  visibility: postVisibilitySchema,
+  mediaUrl: z
+    .string()
+    .trim()
+    .url("Enter a valid URL")
+    .optional()
+    .or(z.literal("")),
+});
+
+export type CreatePostInput = z.infer<typeof createPostSchema>;
+export type PostVisibility = z.infer<typeof postVisibilitySchema>;

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,14 +1,31 @@
+export type UserRole = "creator" | "fan";
+
+export interface User {
+  id: string;
+  email: string;
+  role: UserRole;
+}
+
 export interface AuthResponse {
   access_token: string;
   refresh_token?: string;
-  user: {
-    id: string;
-    email: string;
-  };
+  user: User;
 }
 
 export interface ApiResponse<T = unknown> {
   data?: T;
   message?: string;
   statusCode?: number;
+}
+
+export type PostVisibility = "public" | "subscribers";
+
+export interface Post {
+  id: string;
+  title: string;
+  body: string;
+  visibility: PostVisibility;
+  mediaUrl?: string;
+  authorId: string;
+  createdAt: string;
 }


### PR DESCRIPTION
## Summary
- Adds the creator-side post composer and post list (`PostComposer.tsx`, `PostList.tsx`) at `/dashboard/posts/new` and `/dashboard/posts`, matching the backend posts API shape.
- Adds `lib/validations/post.ts` (zod schema with title/body character limits) and `lib/api/posts.ts` (create/list calls).
- Adds creator-only route protection via `CreatorGuard`, which redirects non-creator users to `/dashboard`. Since the session didn't previously track a role, `User`/`UserRole` were added to `types/api.ts` and `api.setCurrentUser`/`getCurrentUser` persist the authenticated user (including role) from the login response.
- Adds a minimal `Badge` UI primitive (visibility badges) consistent with the existing shadcn-style components.

## Notes
- No toast library exists yet in the repo, so the "success toast" requirement is implemented as a dismissible inline banner shown on the list page after a redirect with `?published=1`.
- Character limits (title 120 / body 5000) are placeholders since no backend limits were documented — easy to adjust once the API contract is finalized.

Closes #26

## Test plan
- [x] `npm run lint` passes
- [x] `npm run build` passes