### PR TITLE
feat: integrate TanStack Query for server state management

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@radix-ui/react-label": "^2.1.4",
         "@radix-ui/react-slot": "^1.2.0",
+        "@tanstack/react-query": "^5.101.0",
+        "@tanstack/react-query-devtools": "^5.101.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.503.0",
@@ -1237,6 +1239,55 @@
         "@tailwindcss/oxide": "4.1.4",
         "postcss": "^8.4.41",
         "tailwindcss": "4.1.4"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.101.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.0.tgz",
+      "integrity": "sha512-cQetA74EB+seWySv1TTKr828TnP0u39m6LykwDXIo84SNortpDkp30TMEjkqtYCNP9c40uT/iwl6MLiufEt0Ow==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.101.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.101.0.tgz",
+      "integrity": "sha512-MVqw17k08RQtGGLEL654+dX/btbX9p/8WjkznO//zusLTMaObxi3Q+MoFwGVkC9K3tqjn8qrrNhJevXx4fJTeQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.101.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.0.tgz",
+      "integrity": "sha512-rLlJXSpkqfizLWgkR5+eLeIk0MvTx/meEIR7LRjxic+qxiQP8zVjq7BqQkiCMNLQBlLfuOLqqr6KO5GtrDlmSg==",
+      "dependencies": {
+        "@tanstack/query-core": "5.101.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.101.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.101.0.tgz",
+      "integrity": "sha512-cpZA0+WqKXwrwMfiWZEGGF6QrIWVQFbhBtxqDF5sQsAfrFf47HIE6fiPbQU3wyAUEN2+7UNqLCQe7oG6m3f93w==",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.101.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.101.0",
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
   "dependencies": {
     "@radix-ui/react-label": "^2.1.4",
     "@radix-ui/react-slot": "^1.2.0",
+    "@tanstack/react-query": "^5.101.0",
+    "@tanstack/react-query-devtools": "^5.101.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.503.0",

--- a/src/app/(dashboard)/discover/page.tsx
+++ b/src/app/(dashboard)/discover/page.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useState } from "react";
+import { useCreators } from "@/hooks/queries/useCreators";
+import { useSubscribe, useUnsubscribe } from "@/hooks/queries/useSubscriptions";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import type { Creator } from "@/types/api";
+
+export default function DiscoverPage() {
+  const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+
+  const { data: creators, isLoading, isError, error } = useCreators({ search: debouncedSearch });
+  const subscribe = useSubscribe();
+  const unsubscribe = useUnsubscribe();
+
+  function handleSearchChange(e: React.ChangeEvent<HTMLInputElement>) {
+    setSearch(e.target.value);
+    const timer = setTimeout(() => setDebouncedSearch(e.target.value), 400);
+    return () => clearTimeout(timer);
+  }
+
+  function handleSubscribeToggle(creator: Creator) {
+    if (creator.isSubscribed) {
+      unsubscribe.mutate(creator.id);
+    } else {
+      subscribe.mutate(creator.id);
+    }
+  }
+
+  return (
+    <main className="mx-auto max-w-4xl px-4 py-8">
+      <h1 className="mb-6 text-2xl font-semibold">Discover Creators</h1>
+
+      <div className="mb-6">
+        <Input
+          placeholder="Search creators..."
+          value={search}
+          onChange={handleSearchChange}
+          className="max-w-sm"
+        />
+      </div>
+
+      {isLoading && (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div
+              key={i}
+              className="h-40 animate-pulse rounded-lg bg-muted"
+            />
+          ))}
+        </div>
+      )}
+
+      {isError && (
+        <p className="text-sm text-destructive">
+          Failed to load creators:{" "}
+          {error instanceof Error ? error.message : "Unknown error"}
+        </p>
+      )}
+
+      {creators && creators.length === 0 && (
+        <p className="text-sm text-muted-foreground">No creators found.</p>
+      )}
+
+      {creators && creators.length > 0 && (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {creators.map((creator) => (
+            <div
+              key={creator.id}
+              className="flex flex-col gap-3 rounded-lg border p-4"
+            >
+              <div className="flex items-center gap-3">
+                {creator.avatarUrl ? (
+                  <img
+                    src={creator.avatarUrl}
+                    alt={creator.name}
+                    className="h-10 w-10 rounded-full object-cover"
+                  />
+                ) : (
+                  <div className="flex h-10 w-10 items-center justify-center rounded-full bg-muted text-sm font-medium">
+                    {creator.name.charAt(0).toUpperCase()}
+                  </div>
+                )}
+                <div className="min-w-0">
+                  <p className="truncate font-medium">{creator.name}</p>
+                  <p className="truncate text-sm text-muted-foreground">
+                    @{creator.handle}
+                  </p>
+                </div>
+              </div>
+
+              {creator.bio && (
+                <p className="line-clamp-2 text-sm text-muted-foreground">
+                  {creator.bio}
+                </p>
+              )}
+
+              <div className="flex items-center justify-between">
+                <span className="text-xs text-muted-foreground">
+                  {creator.subscriberCount.toLocaleString()} subscribers
+                </span>
+                <Button
+                  size="sm"
+                  variant={creator.isSubscribed ? "outline" : "default"}
+                  onClick={() => handleSubscribeToggle(creator)}
+                  disabled={subscribe.isPending || unsubscribe.isPending}
+                >
+                  {creator.isSubscribed ? "Unsubscribe" : "Subscribe"}
+                </Button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </main>
+  );
+}

--- a/src/app/(dashboard)/discover/page.tsx
+++ b/src/app/(dashboard)/discover/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Image from "next/image";
 import { useCreators } from "@/hooks/queries/useCreators";
 import { useSubscribe, useUnsubscribe } from "@/hooks/queries/useSubscriptions";
 import { Input } from "@/components/ui/input";
@@ -73,9 +74,11 @@ export default function DiscoverPage() {
             >
               <div className="flex items-center gap-3">
                 {creator.avatarUrl ? (
-                  <img
+                  <Image
                     src={creator.avatarUrl}
                     alt={creator.name}
+                    width={40}
+                    height={40}
                     className="h-10 w-10 rounded-full object-cover"
                   />
                 ) : (

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { QueryProvider } from "@/lib/query/client";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -27,7 +28,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <QueryProvider>{children}</QueryProvider>
       </body>
     </html>
   );

--- a/src/hooks/queries/useCreator.ts
+++ b/src/hooks/queries/useCreator.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api/client";
+import { queryKeys } from "@/lib/query-keys";
+import type { Creator } from "@/types/api";
+
+export function useCreator(handle: string) {
+  return useQuery({
+    queryKey: queryKeys.creators.detail(handle),
+    queryFn: () => api.get<Creator>(`/creators/${handle}`),
+    enabled: !!handle,
+  });
+}

--- a/src/hooks/queries/useCreators.ts
+++ b/src/hooks/queries/useCreators.ts
@@ -1,0 +1,26 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api/client";
+import { queryKeys } from "@/lib/query-keys";
+import type { Creator } from "@/types/api";
+
+interface UseCreatorsOptions {
+  search?: string;
+  page?: number;
+  limit?: number;
+}
+
+export function useCreators(options: UseCreatorsOptions = {}) {
+  const { search, page = 1, limit = 20 } = options;
+
+  return useQuery({
+    queryKey: queryKeys.creators.list({ search, page, limit }),
+    queryFn: () =>
+      api.get<Creator[]>("/creators", {
+        params: {
+          ...(search && { search }),
+          page,
+          limit,
+        },
+      }),
+  });
+}

--- a/src/hooks/queries/useCurrentUser.ts
+++ b/src/hooks/queries/useCurrentUser.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api/client";
+import { queryKeys } from "@/lib/query-keys";
+import type { User } from "@/types/api";
+
+export function useCurrentUser() {
+  return useQuery({
+    queryKey: queryKeys.users.current(),
+    queryFn: () => api.get<User>("/users/me"),
+    enabled: typeof window !== "undefined" && !!api.getToken(),
+  });
+}

--- a/src/hooks/queries/useSubscriptions.ts
+++ b/src/hooks/queries/useSubscriptions.ts
@@ -1,0 +1,38 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api/client";
+import { queryKeys } from "@/lib/query-keys";
+import type { Subscription } from "@/types/api";
+
+export function useSubscriptions() {
+  return useQuery({
+    queryKey: queryKeys.subscriptions.list(),
+    queryFn: () => api.get<Subscription[]>("/subscriptions"),
+    enabled: typeof window !== "undefined" && !!api.getToken(),
+  });
+}
+
+export function useSubscribe() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (creatorId: string) =>
+      api.post<Subscription>("/subscriptions", { creatorId }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.subscriptions.all });
+      queryClient.invalidateQueries({ queryKey: queryKeys.creators.all });
+    },
+  });
+}
+
+export function useUnsubscribe() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (subscriptionId: string) =>
+      api.delete(`/subscriptions/${subscriptionId}`),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.subscriptions.all });
+      queryClient.invalidateQueries({ queryKey: queryKeys.creators.all });
+    },
+  });
+}

--- a/src/lib/query-keys.ts
+++ b/src/lib/query-keys.ts
@@ -1,0 +1,22 @@
+export const queryKeys = {
+  users: {
+    all: ["users"] as const,
+    current: () => ["users", "current"] as const,
+    detail: (id: string) => ["users", id] as const,
+  },
+  creators: {
+    all: ["creators"] as const,
+    lists: () => ["creators", "list"] as const,
+    list: (filters?: Record<string, unknown>) =>
+      [...queryKeys.creators.lists(), filters] as const,
+    details: () => ["creators", "detail"] as const,
+    detail: (handle: string) =>
+      [...queryKeys.creators.details(), handle] as const,
+  },
+  subscriptions: {
+    all: ["subscriptions"] as const,
+    lists: () => ["subscriptions", "list"] as const,
+    list: (userId?: string) =>
+      [...queryKeys.subscriptions.lists(), userId] as const,
+  },
+};

--- a/src/lib/query/client.tsx
+++ b/src/lib/query/client.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { useState } from "react";
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 30 * 1000,
+        retry: 1,
+        refetchOnWindowFocus: true,
+      },
+    },
+  });
+}
+
+let browserQueryClient: QueryClient | undefined;
+
+function getQueryClient() {
+  if (typeof window === "undefined") {
+    return makeQueryClient();
+  }
+  if (!browserQueryClient) {
+    browserQueryClient = makeQueryClient();
+  }
+  return browserQueryClient;
+}
+
+export function QueryProvider({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(() => getQueryClient());
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+      {process.env.NODE_ENV === "development" && (
+        <ReactQueryDevtools initialIsOpen={false} />
+      )}
+    </QueryClientProvider>
+  );
+}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -12,3 +12,31 @@ export interface ApiResponse<T = unknown> {
   message?: string;
   statusCode?: number;
 }
+
+export interface User {
+  id: string;
+  email: string;
+  name: string;
+  handle: string;
+  avatarUrl?: string;
+  bio?: string;
+  createdAt: string;
+}
+
+export interface Creator {
+  id: string;
+  handle: string;
+  name: string;
+  avatarUrl?: string;
+  bio?: string;
+  subscriberCount: number;
+  isSubscribed?: boolean;
+}
+
+export interface Subscription {
+  id: string;
+  creatorId: string;
+  creator: Creator;
+  subscribedAt: string;
+  expiresAt?: string;
+}


### PR DESCRIPTION
## Summary

Closes #23

Integrates TanStack Query (`@tanstack/react-query`) for scalable server state management across the app.

### What's changed

- **`lib/query/client.tsx`** — `QueryProvider` wrapper (client component) with `QueryClient` configured for `staleTime: 30s`, `retry: 1`, `refetchOnWindowFocus: true`. Devtools only render in development.
- **`lib/query-keys.ts`** — Typed query keys factory for `users`, `creators`, and `subscriptions` — single source of truth for cache keys.
- **`hooks/queries/useCurrentUser.ts`** — Fetches the authenticated user; skips query if no token.
- **`hooks/queries/useCreators.ts`** — Fetches creator list with optional `search`, `page`, `limit` filters.
- **`hooks/queries/useCreator.ts`** — Fetches a single creator by handle.
- **`hooks/queries/useSubscriptions.ts`** — Fetches user subscriptions + `useSubscribe`/`useUnsubscribe` mutations that invalidate subscription and creator caches on success.
- **`app/layout.tsx`** — Root layout wrapped with `QueryProvider` (client boundary respected; server components untouched).
- **`app/(dashboard)/discover/page.tsx`** — New discover page migrated to `useCreators` with skeleton loading, error state, and subscribe/unsubscribe actions driven by query status.
- **`types/api.ts`** — Extended with `User`, `Creator`, and `Subscription` interfaces.

### Acceptance criteria met

| Criteria | Status |
|---|---|
| Duplicate mounts do not duplicate network requests (deduped) | ✅ TanStack Query deduplicates in-flight requests by key |
| Loading/error UI driven by query status | ✅ Discover page uses `isLoading` / `isError` from `useCreators` |
| Mutation success invalidates related lists | ✅ `useSubscribe`/`useUnsubscribe` call `invalidateQueries` on subscriptions and creators |
| SSR boundaries respected | ✅ `QueryProvider` is `"use client"`, root layout is server component |
| Build passes | ✅ `tsc --noEmit` exits clean |
| Devtools in development only | ✅ Guarded by `process.env.NODE_ENV === "development"` |


Closes #23