### PR TITLE
feat(auth): wire login and signup pages to backend API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Base URL of the MyFans NestJS backend
+# Development default: http://localhost:3000
+# Must be prefixed with NEXT_PUBLIC_ so it is inlined into the browser bundle.
+NEXT_PUBLIC_API_URL=http://localhost:3000

--- a/src/app/login/login-form.tsx
+++ b/src/app/login/login-form.tsx
@@ -4,7 +4,8 @@ import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter, useSearchParams } from "next/navigation";
-import { api } from "@/lib/api/client";
+import { login, extractApiErrorMessage } from "@/lib/api/auth";
+import { ApiError } from "@/lib/api/errors";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -16,7 +17,6 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { loginSchema, type LoginFormValues } from "@/lib/validations/auth";
-import type { AuthResponse } from "@/types/api";
 
 export function LoginForm() {
   const router = useRouter();
@@ -24,23 +24,22 @@ export function LoginForm() {
   const redirectTo = searchParams.get("redirect") || "/dashboard";
   const [serverError, setServerError] = useState<string | null>(null);
 
-  // useForm wires up RHF with our Zod schema as the validator.
-  // zodResolver translates Zod errors into the format RHF expects.
   const form = useForm<LoginFormValues>({
     resolver: zodResolver(loginSchema),
     defaultValues: { email: "", password: "" },
   });
 
-  // This function only runs when ALL fields pass Zod validation.
   async function onSubmit(values: LoginFormValues) {
     setServerError(null);
     try {
-      const response = await api.post<AuthResponse>("/auth/login", values);
-      api.setToken(response.access_token);
-      api.setCurrentUser(response.user);
+      await login(values);
       router.replace(redirectTo);
-    } catch {
-      setServerError("Login failed. Check your credentials and try again.");
+    } catch (error) {
+      if (error instanceof ApiError && error.statusCode === 401) {
+        setServerError("Invalid email or password.");
+      } else {
+        setServerError(extractApiErrorMessage(error));
+      }
     }
   }
 
@@ -49,21 +48,17 @@ export function LoginForm() {
       <div className="w-full max-w-md space-y-4 rounded-lg border p-6">
         <h1 className="text-2xl font-semibold">Log in</h1>
 
-        {/* Form spreads the RHF context so all FormField children can access it */}
         <Form {...form}>
           <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
-
             <FormField
               control={form.control}
               name="email"
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>Email</FormLabel>
-                  {/* FormControl merges id + aria-invalid onto the Input */}
                   <FormControl>
                     <Input type="email" placeholder="you@example.com" {...field} />
                   </FormControl>
-                  {/* Renders the Zod error message, or nothing when valid */}
                   <FormMessage />
                 </FormItem>
               )}
@@ -84,7 +79,9 @@ export function LoginForm() {
             />
 
             {serverError ? (
-              <p className="text-sm text-destructive">{serverError}</p>
+              <p role="alert" className="text-sm text-destructive">
+                {serverError}
+              </p>
             ) : null}
 
             <Button

--- a/src/app/signup/signup-form.tsx
+++ b/src/app/signup/signup-form.tsx
@@ -4,7 +4,8 @@ import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/navigation";
-import { api } from "@/lib/api/client";
+import { signup, extractApiErrorMessage } from "@/lib/api/auth";
+import { ApiError } from "@/lib/api/errors";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -16,7 +17,6 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { signupSchema, type SignupFormValues } from "@/lib/validations/auth";
-import type { AuthResponse } from "@/types/api";
 
 export function SignupForm() {
   const router = useRouter();
@@ -30,14 +30,14 @@ export function SignupForm() {
   async function onSubmit(values: SignupFormValues) {
     setServerError(null);
     try {
-      const response = await api.post<AuthResponse>("/auth/signup", {
-        email: values.email,
-        password: values.password,
-      });
-      api.setToken(response.access_token);
+      await signup({ email: values.email, password: values.password });
       router.replace("/dashboard");
-    } catch {
-      setServerError("Sign up failed. This email may already be in use.");
+    } catch (error) {
+      if (error instanceof ApiError && error.statusCode === 409) {
+        setServerError("An account with this email already exists.");
+      } else {
+        setServerError(extractApiErrorMessage(error));
+      }
     }
   }
 
@@ -48,7 +48,6 @@ export function SignupForm() {
 
         <Form {...form}>
           <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
-
             <FormField
               control={form.control}
               name="email"
@@ -86,14 +85,15 @@ export function SignupForm() {
                   <FormControl>
                     <Input type="password" placeholder="••••••••" {...field} />
                   </FormControl>
-                  {/* This message comes from the .refine() cross-field check */}
                   <FormMessage />
                 </FormItem>
               )}
             />
 
             {serverError ? (
-              <p className="text-sm text-destructive">{serverError}</p>
+              <p role="alert" className="text-sm text-destructive">
+                {serverError}
+              </p>
             ) : null}
 
             <Button

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -1,0 +1,46 @@
+import { api } from "./client";
+import { ApiError, NetworkError } from "./errors";
+import type { AuthResponse } from "@/types/api";
+import type { LoginFormValues, SignupFormValues } from "@/lib/validations/auth";
+
+export async function login(credentials: LoginFormValues): Promise<AuthResponse> {
+  const response = await api.post<AuthResponse>("/auth/login", credentials);
+  api.setToken(response.access_token);
+  api.setCurrentUser(response.user);
+  return response;
+}
+
+export async function signup(
+  values: Pick<SignupFormValues, "email" | "password">
+): Promise<AuthResponse> {
+  const response = await api.post<AuthResponse>("/auth/signup", values);
+  api.setToken(response.access_token);
+  api.setCurrentUser(response.user);
+  return response;
+}
+
+export function logout(): void {
+  api.clearToken();
+  api.clearCurrentUser();
+}
+
+/**
+ * Extracts a human-readable message from an API or network error.
+ * NestJS validation errors arrive as message arrays; credential/conflict
+ * errors arrive as a single string.
+ */
+export function extractApiErrorMessage(error: unknown): string {
+  if (error instanceof ApiError) {
+    const data = error.data as { message?: string | string[] } | null;
+    if (data?.message) {
+      return Array.isArray(data.message)
+        ? data.message.join(". ")
+        : data.message;
+    }
+    return error.message;
+  }
+  if (error instanceof NetworkError) {
+    return "Could not reach the server. Check your connection and try again.";
+  }
+  return "An unexpected error occurred. Please try again.";
+}


### PR DESCRIPTION
Closes #12

## Summary

Completes the first full-stack auth vertical slice by connecting the existing login/signup UI to the NestJS backend.

- **`src/lib/api/auth.ts`** — new typed auth module with `login()`, `signup()`, `logout()`, and `extractApiErrorMessage()`. Both mutation functions call the backend, then store the JWT and user profile so subsequent API calls are authenticated immediately.
- **`LoginForm`** — now calls `login()` instead of raw `api.post`. Real API error messages (NestJS validation arrays are joined; 401 maps to a credential-specific message; network failures show a connectivity message). Added `role="alert"` on the error paragraph for screen readers.
- **`SignupForm`** — now calls `signup()`. Fixes a bug where `api.setCurrentUser()` was never called after signup, so the user profile was never persisted. 409 Conflict maps to an email-already-in-use message. Same real-error-message surfacing as login.
- **`.env.example`** — documents the required `NEXT_PUBLIC_API_URL` variable (force-committed since `.gitignore` excluded `.env*` patterns).

## What's in scope

| Deliverable | Status |
|---|---|
| `lib/api/auth.ts` with `login()` and `signup()` | ✅ |
| Token stored on success (localStorage + cookie via existing `setAuthCookie`) | ✅ |
| Current-user stored on success | ✅ (signup was missing this — fixed) |
| API validation errors surfaced in form UI | ✅ |
| Network failure messaging | ✅ (inline error; see note below) |
| Redirect to `/dashboard` after login/signup | ✅ |
| Redirect param honoured on login | ✅ (existing `?redirect=` logic preserved) |
| `.env.example` updated | ✅ |

## Notes

**Token storage tradeoff:** Tokens are stored in `localStorage` (readable by JS) and mirrored into a non-httpOnly cookie (used by `middleware.ts` for SSR route protection). An httpOnly-only approach would require a Next.js API route acting as a proxy to set the cookie server-side. The current dual-storage approach is the simplest path consistent with the existing `client.ts` architecture; the tradeoff is documented in `src/lib/api/README.md`.

**Toast notifications:** No toast library is currently in the project's dependencies. Network failures are displayed inline in the form's existing error area (consistent with how validation and API errors are shown) to avoid pulling in a new dependency. Adding `sonner` or similar can be a follow-up if the team decides to standardise toast-based feedback.

**CORS:** The backend must allow `http://localhost:3000` (or wherever the frontend runs) as an origin. Set `NEXT_PUBLIC_API_URL` in `.env.local` to point at the backend.

