### PR TITLE
Feat: Creators profile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "next": "15.3.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-hook-form": "^7.79.0",
         "tailwind-merge": "^3.2.0",
         "zod": "^4.4.3"
       },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "next": "15.3.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-hook-form": "^7.79.0",
     "tailwind-merge": "^3.2.0",
     "zod": "^4.4.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,12 +8,21 @@ importers:
 
   .:
     dependencies:
+      '@hookform/resolvers':
+        specifier: ^5.4.0
+        version: 5.4.0(react-hook-form@7.79.0(react@19.1.0))
       '@radix-ui/react-label':
         specifier: ^2.1.4
         version: 2.1.4(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-slot':
         specifier: ^1.2.0
         version: 1.2.0(@types/react@19.1.2)(react@19.1.0)
+      '@tanstack/react-query':
+        specifier: ^5.101.0
+        version: 5.101.0(react@19.1.0)
+      '@tanstack/react-query-devtools':
+        specifier: ^5.101.0
+        version: 5.101.0(@tanstack/react-query@5.101.0(react@19.1.0))(react@19.1.0)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -32,9 +41,15 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.1.0(react@19.1.0)
+      react-hook-form:
+        specifier: ^7.79.0
+        version: 7.79.0(react@19.1.0)
       tailwind-merge:
         specifier: ^3.2.0
         version: 3.2.0
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3
@@ -120,6 +135,11 @@ packages:
     resolution: {integrity: sha512-ZAoA40rNMPwSm+AeHpCq8STiNAwzWLJuP8Xv4CHIc9wv/PSuExjMrmjfYNj682vW0OOiZ1HKxzvjQr9XZIisQA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@hookform/resolvers@5.4.0':
+    resolution: {integrity: sha512-EIsqr/t/qbinPIhGjMdtvutIN1Kk4uwbROE9/UQ93CAVGR7GkA7Y92+fX80OzXi/OB67jVFYwKGO1WzkxmkFZw==}
+    peerDependencies:
+      react-hook-form: ^7.55.0
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -166,72 +186,85 @@ packages:
     resolution: {integrity: sha512-IVfGJa7gjChDET1dK9SekxFFdflarnUB8PwW8aGwEoF3oAsSDuNUTYS+SKDOyOJxQyDC1aPFMuRYLoDInyV9Ew==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.1.0':
     resolution: {integrity: sha512-s8BAd0lwUIvYCJyRdFqvsj+BJIpDBSxs6ivrOPm/R7piTs5UIwY5OjXrP2bqXC9/moGsyRa37eYWYCOGVXxVrA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.1.0':
     resolution: {integrity: sha512-tiXxFZFbhnkWE2LA8oQj7KYR+bWBkiV2nilRldT7bqoEZ4HiDOcePr9wVDAZPi/Id5fT1oY9iGnDq20cwUz8lQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.1.0':
     resolution: {integrity: sha512-xukSwvhguw7COyzvmjydRb3x/09+21HykyapcZchiCUkTThEQEOMtBj9UhkaBRLuBrgLFzQ2wbxdeCCJW/jgJA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.1.0':
     resolution: {integrity: sha512-yRj2+reB8iMg9W5sULM3S74jVS7zqSzHG3Ol/twnAAkAhnGQnpjj6e4ayUz7V+FpKypwgs82xbRdYtchTTUB+Q==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.1.0':
     resolution: {integrity: sha512-jYZdG+whg0MDK+q2COKbYidaqW/WTz0cc1E+tMAusiDygrM4ypmSCjOJPmFTvHHJ8j/6cAGyeDWZOsK06tP33w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.1.0':
     resolution: {integrity: sha512-wK7SBdwrAiycjXdkPnGCPLjYb9lD4l6Ze2gSdAGVZrEL05AOUJESWU2lhlC+Ffn5/G+VKuSm6zzbQSzFX/P65A==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.1':
     resolution: {integrity: sha512-kX2c+vbvaXC6vly1RDf/IWNXxrlxLNpBVWkdpRq5Ka7OOKj6nr66etKy2IENf6FtOgklkg9ZdGpEu9kwdlcwOQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.1':
     resolution: {integrity: sha512-anKiszvACti2sGy9CirTlNyk7BjjZPiML1jt2ZkTdcvpLU1YH6CXwRAZCA2UmRXnhiIftXQ7+Oh62Ji25W72jA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.1':
     resolution: {integrity: sha512-7s0KX2tI9mZI2buRipKIw2X1ufdTeaRgwmRabt5bi9chYfhur+/C1OXg3TKg/eag1W+6CCWLVmSauV1owmRPxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.1':
     resolution: {integrity: sha512-wExv7SH9nmoBW3Wr2gvQopX1k8q2g5V5Iag8Zk6AVENsjwd+3adjwxtp3Dcu2QhOXr8W9NusBU6XcQUohBZ5MA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.1':
     resolution: {integrity: sha512-DfvyxzHxw4WGdPiTF0SOHnm11Xv4aQexvqhRDAoD00MzHekAj9a/jADXeXYCDFH/DzYruwHbXU7uz+H+nWmSOQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.1':
     resolution: {integrity: sha512-pax/kTR407vNb9qaSIiWVnQplPcGU8LRIJpDT5o8PdAx5aAA7AS3X9PS8Isw1/WfqgQorPotjrZL3Pqh6C5EBg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.1':
     resolution: {integrity: sha512-YDybQnYrLQfEpzGOQe7OKcyLUCML4YOXl428gOOzBgN6Gw0rv8dpsJ7PqTHxBnXnwXr8S1mYFSLSa727tpz0xg==}
@@ -276,24 +309,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@15.3.1':
     resolution: {integrity: sha512-IIxXEXRti/AulO9lWRHiCpUUR8AR/ZYLPALgiIg/9ENzMzLn3l0NSxVdva7R/VDcuSEBo0eGVCe3evSIHNz0Hg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@15.3.1':
     resolution: {integrity: sha512-bfI4AMhySJbyXQIKH5rmLJ5/BP7bPwuxauTvVEiJ/ADoddaA9fgyNNCcsbu9SlqfHDoZmfI6g2EjzLwbsVTr5A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@15.3.1':
     resolution: {integrity: sha512-FeAbR7FYMWR+Z+M5iSGytVryKHiAsc0x3Nc3J+FD5NVbD5Mqz7fTSy8CYliXinn7T26nDMbpExRUI/4ekTvoiA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@15.3.1':
     resolution: {integrity: sha512-yP7FueWjphQEPpJQ2oKmshk/ppOt+0/bB8JC8svPUZNy0Pi3KbPx2Llkzv1p8CoQa+D2wknINlJpHf3vtChVBw==}
@@ -373,6 +410,9 @@ packages:
   '@rushstack/eslint-patch@1.11.0':
     resolution: {integrity: sha512-zxnHvoMQVqewTJr/W4pKjF0bMGiKJv1WX7bSrkl46Hg0QjESbzBROWK0Wg4RphzSOS5Jiy7eFimmM3UgMrMZbQ==}
 
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
+
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
 
@@ -417,24 +457,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.4':
     resolution: {integrity: sha512-X3As2xhtgPTY/m5edUtddmZ8rCruvBvtxYLMw9OsZdH01L2gS2icsHRwxdU0dMItNfVmrBezueXZCHxVeeb7Aw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.4':
     resolution: {integrity: sha512-2VG4DqhGaDSmYIu6C4ua2vSLXnJsb/C9liej7TuSO04NK+JJJgJucDUgmX6sn7Gw3Cs5ZJ9ZLrnI0QRDOjLfNQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.4':
     resolution: {integrity: sha512-v+mxVgH2kmur/X5Mdrz9m7TsoVjbdYQT0b4Z+dr+I4RvreCNXyCFELZL/DO0M1RsidZTrm6O1eMnV6zlgEzTMQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.4':
     resolution: {integrity: sha512-2TLe9ir+9esCf6Wm+lLWTMbgklIjiF0pbmDnwmhR9MksVOq+e8aP3TSsXySnBDDvTTVd/vKu1aNttEGj3P6l8Q==}
@@ -466,6 +510,23 @@ packages:
 
   '@tailwindcss/postcss@4.1.4':
     resolution: {integrity: sha512-bjV6sqycCEa+AQSt2Kr7wpGF1bOZJ5wsqnLEkqSbM/JEHxx/yhMH8wHmdkPyApF9xhHeMSwnnkDUUMMM/hYnXw==}
+
+  '@tanstack/query-core@5.101.0':
+    resolution: {integrity: sha512-cQetA74EB+seWySv1TTKr828TnP0u39m6LykwDXIo84SNortpDkp30TMEjkqtYCNP9c40uT/iwl6MLiufEt0Ow==}
+
+  '@tanstack/query-devtools@5.101.0':
+    resolution: {integrity: sha512-MVqw17k08RQtGGLEL654+dX/btbX9p/8WjkznO//zusLTMaObxi3Q+MoFwGVkC9K3tqjn8qrrNhJevXx4fJTeQ==}
+
+  '@tanstack/react-query-devtools@5.101.0':
+    resolution: {integrity: sha512-cpZA0+WqKXwrwMfiWZEGGF6QrIWVQFbhBtxqDF5sQsAfrFf47HIE6fiPbQU3wyAUEN2+7UNqLCQe7oG6m3f93w==}
+    peerDependencies:
+      '@tanstack/react-query': ^5.101.0
+      react: ^18 || ^19
+
+  '@tanstack/react-query@5.101.0':
+    resolution: {integrity: sha512-rLlJXSpkqfizLWgkR5+eLeIk0MvTx/meEIR7LRjxic+qxiQP8zVjq7BqQkiCMNLQBlLfuOLqqr6KO5GtrDlmSg==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@tybys/wasm-util@0.9.0':
     resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
@@ -566,41 +627,49 @@ packages:
     resolution: {integrity: sha512-jon9M7DKRLGZ9VYSkFMflvNqu9hDtOCEnO2QAryFWgT6o6AXU8du56V7YqnaLKr6rAbZBWYsYpikF226v423QA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.7.2':
     resolution: {integrity: sha512-c8Cg4/h+kQ63pL43wBNaVMmOjXI/X62wQmru51qjfTvI7kmCy5uHTJvK/9LrF0G8Jdx8r34d019P1DVJmhXQpA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.7.2':
     resolution: {integrity: sha512-A+lcwRFyrjeJmv3JJvhz5NbcCkLQL6Mk16kHTNm6/aGNc4FwPHPE4DR9DwuCvCnVHvF5IAd9U4VIs/VvVir5lg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.7.2':
     resolution: {integrity: sha512-hQQ4TJQrSQW8JlPm7tRpXN8OCNP9ez7PajJNjRD1ZTHQAy685OYqPrKjfaMw/8LiHCt8AZ74rfUVHP9vn0N69Q==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.7.2':
     resolution: {integrity: sha512-NoAGbiqrxtY8kVooZ24i70CjLDlUFI7nDj3I9y54U94p+3kPxwd2L692YsdLa+cqQ0VoqMWoehDFp21PKRUoIQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.7.2':
     resolution: {integrity: sha512-KaZByo8xuQZbUhhreBTW+yUnOIHUsv04P8lKjQ5otiGoSJ17ISGYArc+4vKdLEpGaLbemGzr4ZeUbYQQsLWFjA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.7.2':
     resolution: {integrity: sha512-dEidzJDubxxhUCBJ/SHSMJD/9q7JkyfBMT77Px1npl4xpg9t0POLvnWywSk66BgZS/b2Hy9Y1yFaoMTFJUe9yg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.7.2':
     resolution: {integrity: sha512-RvP+Ux3wDjmnZDT4XWFfNBRVG0fMsc+yVzNFUqOflnDfZ9OYujv6nkh+GOr+watwrW4wdp6ASfG/e7bkDradsw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.7.2':
     resolution: {integrity: sha512-y797JBmO9IsvXVRCKDXOxjyAE4+CcZpla2GSoBQ33TVb3ILXuFnMrbR/QQZoauBYeOFuu4w3ifWLw52sdHGz6g==}
@@ -1313,24 +1382,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.29.2:
     resolution: {integrity: sha512-Q64eM1bPlOOUgxFmoPUefqzY1yV3ctFPE6d/Vt7WzLW4rKTv7MyYNky+FWxRpLkNASTnKQUaiMJ87zNODIrrKQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.29.2:
     resolution: {integrity: sha512-0v6idDCPG6epLXtBH/RPkHvYx74CVziHo6TMYga8O2EiQApnUPZsbR9nFNrg2cgBzk1AYqEd95TlrsL7nYABQg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.29.2:
     resolution: {integrity: sha512-rMpz2yawkgGT8RULc5S4WiZopVMOFWjiItBT7aSfDX4NQav6M44rhn5hjtkKzB+wMTRlLLqxkeYEtQ3dd9696w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.29.2:
     resolution: {integrity: sha512-nL7zRW6evGQqYVu/bKGK+zShyz8OVzsCotFgc7judbt6wnB2KbiKKJwBE4SGoDBQ1O94RjW4asrCjQL4i8Fhbw==}
@@ -1405,6 +1478,7 @@ packages:
   next@15.3.1:
     resolution: {integrity: sha512-8+dDV0xNLOgHlyBxP1GwHGVaNXsmp+2NhZEYrXr24GWLHtt27YrBPbPuHvzlhi7kZNYjeJNR93IF5zfFu5UL0g==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
+    deprecated: This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/CVE-2025-66478 for more details.
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
@@ -1527,6 +1601,12 @@ packages:
     resolution: {integrity: sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==}
     peerDependencies:
       react: ^19.1.0
+
+  react-hook-form@7.79.0:
+    resolution: {integrity: sha512-mhYp/MTmXvzYX6AJcJVko0rktoIhhmRnEouObj4wF5i/tCttgJvnp1+9wRkpITZjDTqpo4IOSJqu0dBlPlV/Lw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -1796,6 +1876,9 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
@@ -1859,6 +1942,11 @@ snapshots:
     dependencies:
       '@eslint/core': 0.13.0
       levn: 0.4.1
+
+  '@hookform/resolvers@5.4.0(react-hook-form@7.79.0(react@19.1.0))':
+    dependencies:
+      '@standard-schema/utils': 0.3.0
+      react-hook-form: 7.79.0(react@19.1.0)
 
   '@humanfs/core@0.19.1': {}
 
@@ -2037,6 +2125,8 @@ snapshots:
 
   '@rushstack/eslint-patch@1.11.0': {}
 
+  '@standard-schema/utils@0.3.0': {}
+
   '@swc/counter@0.1.3': {}
 
   '@swc/helpers@0.5.15':
@@ -2108,6 +2198,21 @@ snapshots:
       '@tailwindcss/oxide': 4.1.4
       postcss: 8.5.3
       tailwindcss: 4.1.4
+
+  '@tanstack/query-core@5.101.0': {}
+
+  '@tanstack/query-devtools@5.101.0': {}
+
+  '@tanstack/react-query-devtools@5.101.0(@tanstack/react-query@5.101.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@tanstack/query-devtools': 5.101.0
+      '@tanstack/react-query': 5.101.0(react@19.1.0)
+      react: 19.1.0
+
+  '@tanstack/react-query@5.101.0(react@19.1.0)':
+    dependencies:
+      '@tanstack/query-core': 5.101.0
+      react: 19.1.0
 
   '@tybys/wasm-util@0.9.0':
     dependencies:
@@ -3340,6 +3445,10 @@ snapshots:
       react: 19.1.0
       scheduler: 0.26.0
 
+  react-hook-form@7.79.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+
   react-is@16.13.1: {}
 
   react@19.1.0: {}
@@ -3723,3 +3832,5 @@ snapshots:
   word-wrap@1.2.5: {}
 
   yocto-queue@0.1.0: {}
+
+  zod@4.4.3: {}

--- a/src/app/creators/[handle]/page.tsx
+++ b/src/app/creators/[handle]/page.tsx
@@ -1,0 +1,132 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { ProfileHeader } from "@/components/creator/ProfileHeader";
+import { SubscribeButton } from "@/components/creator/SubscribeButton";
+import { getCreatorByHandle } from "@/lib/api/creators";
+import { isAuthenticated } from "@/lib/auth/session.server";
+import type { CreatorPostPreview } from "@/types/api";
+
+interface CreatorPageProps {
+  params: Promise<{
+    handle: string;
+  }>;
+}
+
+function formatPostDate(date: string): string {
+  return new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+    year: "numeric",
+  }).format(new Date(date));
+}
+
+function PostsSection({ posts }: { posts: CreatorPostPreview[] }) {
+  return (
+    <section className="mt-8 space-y-4">
+      <div className="flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <h2 className="text-xl font-semibold">Posts</h2>
+          <p className="text-sm text-muted-foreground">
+            Public previews from this creator.
+          </p>
+        </div>
+      </div>
+
+      {posts.length > 0 ? (
+        <div className="grid gap-4 sm:grid-cols-2">
+          {posts.map((post) => (
+            <article
+              key={post.id}
+              className="rounded-lg border bg-card p-4 shadow-sm"
+            >
+              <p className="text-xs text-muted-foreground">
+                {formatPostDate(post.publishedAt)}
+              </p>
+              <h3 className="mt-2 font-semibold">{post.title}</h3>
+              <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                {post.excerpt}
+              </p>
+            </article>
+          ))}
+        </div>
+      ) : (
+        <div className="rounded-lg border border-dashed bg-card p-8 text-center">
+          <h3 className="font-semibold">Posts coming soon</h3>
+          <p className="mt-2 text-sm text-muted-foreground">
+            This creator has not published public previews yet.
+          </p>
+        </div>
+      )}
+    </section>
+  );
+}
+
+export async function generateMetadata({
+  params,
+}: CreatorPageProps): Promise<Metadata> {
+  const { handle } = await params;
+  const creator = await getCreatorByHandle(handle);
+
+  if (!creator) {
+    return {
+      title: "Creator not found | MyFans",
+    };
+  }
+
+  return {
+    title: `${creator.displayName} (@${creator.handle}) | MyFans`,
+    description: creator.bio,
+  };
+}
+
+export default async function CreatorPublicProfilePage({
+  params,
+}: CreatorPageProps) {
+  const { handle } = await params;
+  const [creator, authenticated] = await Promise.all([
+    getCreatorByHandle(handle),
+    isAuthenticated(),
+  ]);
+
+  if (!creator) {
+    notFound();
+  }
+
+  return (
+    <main className="min-h-screen bg-background text-foreground">
+      <header className="border-b bg-background/95 backdrop-blur">
+        <div className="mx-auto flex h-16 max-w-5xl items-center justify-between gap-4 px-4 sm:px-6">
+          <Link href="/" className="text-sm font-semibold">
+            MyFans
+          </Link>
+          {!authenticated ? (
+            <Link
+              href={`/login?redirect=${encodeURIComponent(`/creators/${creator.handle}`)}`}
+              className="text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+            >
+              Log in
+            </Link>
+          ) : null}
+        </div>
+      </header>
+
+      <div className="mx-auto max-w-5xl px-4 py-6 sm:px-6 sm:py-8">
+        <ProfileHeader
+          creator={creator}
+          action={
+            <SubscribeButton
+              creatorId={creator.id}
+              creatorUserId={creator.userId}
+              creatorHandle={creator.handle}
+              isAuthenticated={authenticated}
+              isSubscribed={creator.isSubscribed}
+            />
+          }
+        />
+        <PostsSection posts={creator.recentPosts ?? []} />
+      </div>
+    </main>
+  );
+}

--- a/src/components/creator/ProfileHeader.tsx
+++ b/src/components/creator/ProfileHeader.tsx
@@ -1,0 +1,81 @@
+import Image from "next/image";
+import { Badge } from "@/components/ui/badge";
+import type { CreatorProfile } from "@/types/api";
+
+interface ProfileHeaderProps {
+  creator: CreatorProfile;
+  action: React.ReactNode;
+}
+
+function getInitials(displayName: string): string {
+  return displayName
+    .split(" ")
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part.charAt(0).toUpperCase())
+    .join("");
+}
+
+export function ProfileHeader({ creator, action }: ProfileHeaderProps) {
+  const initials = getInitials(creator.displayName);
+
+  return (
+    <section className="overflow-hidden rounded-lg border bg-card shadow-sm">
+      <div className="relative aspect-[3/1] min-h-36 overflow-hidden bg-muted sm:aspect-[4/1]">
+        {creator.bannerUrl ? (
+          <Image
+            src={creator.bannerUrl}
+            alt={`${creator.displayName} banner`}
+            fill
+            sizes="(max-width: 640px) 100vw, 1024px"
+            className="absolute inset-0 h-full w-full object-cover"
+            priority
+            unoptimized
+          />
+        ) : (
+          <div className="absolute inset-0 bg-[linear-gradient(135deg,#111827,#374151_48%,#e5e7eb)]" />
+        )}
+      </div>
+
+      <div className="px-4 pb-6 sm:px-6">
+        <div className="-mt-12 flex flex-col gap-5 sm:-mt-14 sm:flex-row sm:items-end sm:justify-between">
+          <div className="flex min-w-0 flex-col gap-4 sm:flex-row sm:items-end">
+            <div className="relative flex h-24 w-24 shrink-0 items-center justify-center overflow-hidden rounded-full border-4 border-background bg-muted text-2xl font-semibold text-muted-foreground sm:h-28 sm:w-28">
+              {creator.avatarUrl ? (
+                <Image
+                  src={creator.avatarUrl}
+                  alt={`${creator.displayName} avatar`}
+                  fill
+                  sizes="112px"
+                  className="absolute inset-0 h-full w-full object-cover"
+                  unoptimized
+                />
+              ) : (
+                <span aria-hidden="true">{initials}</span>
+              )}
+            </div>
+
+            <div className="min-w-0 space-y-2 pt-1 sm:pb-1">
+              <div className="flex flex-wrap items-center gap-2">
+                <h1 className="break-words text-2xl font-semibold tracking-tight sm:text-3xl">
+                  {creator.displayName}
+                </h1>
+                <Badge variant="secondary">{creator.category}</Badge>
+              </div>
+              <p className="text-sm text-muted-foreground">@{creator.handle}</p>
+              <p className="text-sm font-medium">
+                {creator.subscriberCount.toLocaleString()} subscribers
+              </p>
+            </div>
+          </div>
+
+          <div className="w-full sm:w-auto">{action}</div>
+        </div>
+
+        <p className="mt-5 max-w-3xl text-sm leading-6 text-muted-foreground sm:text-base">
+          {creator.bio}
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/src/components/creator/SubscribeButton.tsx
+++ b/src/components/creator/SubscribeButton.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { api } from "@/lib/api/client";
+import { useCurrentUser } from "@/hooks/queries/useCurrentUser";
+import { useSubscribe } from "@/hooks/queries/useSubscriptions";
+import { Button } from "@/components/ui/button";
+import type { User } from "@/types/api";
+
+interface SubscribeButtonProps {
+  creatorId: string;
+  creatorUserId?: string;
+  creatorHandle: string;
+  isAuthenticated: boolean;
+  isSubscribed?: boolean;
+}
+
+export function SubscribeButton({
+  creatorId,
+  creatorUserId,
+  creatorHandle,
+  isAuthenticated,
+  isSubscribed = false,
+}: SubscribeButtonProps) {
+  const currentUserQuery = useCurrentUser();
+  const subscribe = useSubscribe();
+  const [storedUser, setStoredUser] = useState<User | null>(null);
+  const [subscribed, setSubscribed] = useState(isSubscribed);
+
+  useEffect(() => {
+    setStoredUser(api.getCurrentUser());
+  }, []);
+
+  const currentUser = currentUserQuery.data ?? storedUser;
+  const isOwnProfile =
+    currentUser?.role === "creator" &&
+    Boolean(currentUser.id === creatorUserId || currentUser.id === creatorId);
+
+  if (!isAuthenticated) {
+    return (
+      <Button asChild className="w-full sm:w-auto">
+        <Link href={`/login?redirect=${encodeURIComponent(`/creators/${creatorHandle}`)}`}>
+          Log in to subscribe
+        </Link>
+      </Button>
+    );
+  }
+
+  if (isOwnProfile) {
+    return (
+      <Button disabled className="w-full sm:w-auto">
+        Your profile
+      </Button>
+    );
+  }
+
+  return (
+    <Button
+      className="w-full sm:w-auto"
+      disabled={subscribe.isPending || subscribed || currentUserQuery.isLoading}
+      onClick={() =>
+        subscribe.mutate(creatorId, {
+          onSuccess: () => setSubscribed(true),
+        })
+      }
+    >
+      {subscribe.isPending
+        ? "Subscribing..."
+        : subscribed
+          ? "Subscribed"
+          : currentUserQuery.isLoading
+            ? "Checking..."
+            : "Subscribe"}
+    </Button>
+  );
+}

--- a/src/lib/api/creators.test.mjs
+++ b/src/lib/api/creators.test.mjs
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  getCreatorByHandle,
+  getMockCreatorByHandle,
+} from "./creators.ts";
+
+test("getMockCreatorByHandle finds mock creators by handle", () => {
+  const creator = getMockCreatorByHandle("luna");
+
+  assert.equal(creator?.displayName, "Luna Vale");
+  assert.equal(creator?.handle, "luna");
+});
+
+test("getCreatorByHandle falls back to mock data when the API is unavailable", async (t) => {
+  const originalFetch = globalThis.fetch;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+  globalThis.fetch = async () => {
+    throw new Error("offline");
+  };
+
+  const creator = await getCreatorByHandle("marco");
+
+  assert.equal(creator?.displayName, "Marco Stone");
+  assert.equal(creator?.handle, "marco");
+});
+
+test("getCreatorByHandle fetches from the configured API URL", async (t) => {
+  const originalFetch = globalThis.fetch;
+  const originalApiUrl = process.env.NEXT_PUBLIC_API_URL;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+    if (originalApiUrl === undefined) {
+      delete process.env.NEXT_PUBLIC_API_URL;
+    } else {
+      process.env.NEXT_PUBLIC_API_URL = originalApiUrl;
+    }
+  });
+  process.env.NEXT_PUBLIC_API_URL = "https://api.myfans.test";
+  globalThis.fetch = async (url) => {
+    assert.equal(String(url), "https://api.myfans.test/creators/luna");
+    return new Response(
+      JSON.stringify({
+        id: "api_luna",
+        userId: "api_user_luna",
+        handle: "luna",
+        displayName: "API Luna",
+        bio: "Loaded from API",
+        category: "Music",
+        subscriberCount: 42,
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } }
+    );
+  };
+
+  const creator = await getCreatorByHandle("luna");
+
+  assert.equal(creator?.id, "api_luna");
+  assert.equal(creator?.displayName, "API Luna");
+  assert.equal(creator?.subscriberCount, 42);
+});
+
+test("getCreatorByHandle returns null for an unknown handle when the API is unavailable", async (t) => {
+  const originalFetch = globalThis.fetch;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+  globalThis.fetch = async () => {
+    throw new Error("offline");
+  };
+
+  const creator = await getCreatorByHandle("unknown-creator");
+
+  assert.equal(creator, null);
+});

--- a/src/lib/api/creators.ts
+++ b/src/lib/api/creators.ts
@@ -1,0 +1,156 @@
+import type { CreatorProfile } from "@/types/api";
+
+type ApiCreatorPayload = Partial<CreatorProfile> & {
+  name?: string;
+  data?: ApiCreatorPayload;
+};
+
+const MOCK_CREATORS: Record<string, CreatorProfile> = {
+  luna: {
+    id: "creator_luna",
+    userId: "user_luna",
+    handle: "luna",
+    name: "Luna Vale",
+    displayName: "Luna Vale",
+    bio: "Cosplay designer sharing build diaries, behind-the-scenes shoots, and monthly fan polls.",
+    category: "Cosplay",
+    avatarUrl: null,
+    bannerUrl: null,
+    subscriberCount: 18420,
+    isSubscribed: false,
+    recentPosts: [
+      {
+        id: "post_luna_1",
+        title: "Armor foam workflow",
+        excerpt: "A quick look at how this month's shoulder pieces came together.",
+        publishedAt: "2026-06-12",
+      },
+      {
+        id: "post_luna_2",
+        title: "June character poll",
+        excerpt: "Subscribers are voting on the next full-build reveal.",
+        publishedAt: "2026-06-05",
+      },
+    ],
+  },
+  marco: {
+    id: "creator_marco",
+    userId: "user_marco",
+    handle: "marco",
+    name: "Marco Stone",
+    displayName: "Marco Stone",
+    bio: "Strength coach posting compact training blocks, recovery notes, and subscriber-only form checks.",
+    category: "Fitness",
+    avatarUrl: null,
+    bannerUrl: null,
+    subscriberCount: 9320,
+    isSubscribed: false,
+    recentPosts: [
+      {
+        id: "post_marco_1",
+        title: "Four-week pull plan",
+        excerpt: "A simple progression for stronger rows, pull-ups, and grip work.",
+        publishedAt: "2026-06-10",
+      },
+    ],
+  },
+  nova: {
+    id: "creator_nova",
+    userId: "user_nova",
+    handle: "nova",
+    name: "Nova Quinn",
+    displayName: "Nova Quinn",
+    bio: "Digital artist creating process breakdowns, brush packs, and long-form critique streams.",
+    category: "Art",
+    avatarUrl: null,
+    bannerUrl: null,
+    subscriberCount: 12780,
+    isSubscribed: false,
+    recentPosts: [],
+  },
+};
+
+function normalizeHandle(handle: string): string {
+  return decodeURIComponent(handle).trim().replace(/^@/, "").toLowerCase();
+}
+
+function getApiUrl(): string | null {
+  return process.env.NEXT_PUBLIC_API_URL || null;
+}
+
+function normalizeCreatorPayload(payload: ApiCreatorPayload): CreatorProfile | null {
+  const source = payload.data ?? payload;
+  const handle = typeof source.handle === "string" ? normalizeHandle(source.handle) : "";
+
+  if (!source.id || !handle) {
+    return null;
+  }
+
+  const displayName = source.displayName || source.name || handle;
+
+  return {
+    id: source.id,
+    userId: source.userId,
+    handle,
+    name: source.name || displayName,
+    displayName,
+    bio: source.bio || "",
+    category: source.category || "Creator",
+    avatarUrl: source.avatarUrl ?? null,
+    bannerUrl: source.bannerUrl ?? null,
+    subscriberCount: source.subscriberCount ?? 0,
+    isSubscribed: source.isSubscribed ?? false,
+    recentPosts: source.recentPosts ?? [],
+  };
+}
+
+export function getMockCreatorByHandle(handle: string): CreatorProfile | null {
+  const normalizedHandle = normalizeHandle(handle);
+  return MOCK_CREATORS[normalizedHandle] ?? null;
+}
+
+async function fetchCreatorByHandle(handle: string): Promise<CreatorProfile | null> {
+  const apiUrl = getApiUrl();
+
+  if (!apiUrl) {
+    return null;
+  }
+
+  const normalizedHandle = normalizeHandle(handle);
+  const url = new URL(`/creators/${encodeURIComponent(normalizedHandle)}`, apiUrl);
+  const response = await fetch(url, {
+    headers: {
+      Accept: "application/json",
+    },
+  });
+
+  if (response.status === 404) {
+    return null;
+  }
+
+  if (!response.ok) {
+    throw new Error(`Failed to load creator ${normalizedHandle}`);
+  }
+
+  const payload = (await response.json()) as ApiCreatorPayload;
+  return normalizeCreatorPayload(payload);
+}
+
+export async function getCreatorByHandle(
+  handle: string
+): Promise<CreatorProfile | null> {
+  const normalizedHandle = normalizeHandle(handle);
+
+  if (!normalizedHandle) {
+    return null;
+  }
+
+  try {
+    return (
+      (await fetchCreatorByHandle(normalizedHandle)) ??
+      getMockCreatorByHandle(normalizedHandle)
+    );
+  } catch {
+    return getMockCreatorByHandle(normalizedHandle);
+  }
+}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -29,3 +29,37 @@ export interface Post {
   authorId: string;
   createdAt: string;
 }
+
+export interface CreatorPostPreview {
+  id: string;
+  title: string;
+  excerpt: string;
+  publishedAt: string;
+}
+
+export interface Creator {
+  id: string;
+  userId?: string;
+  handle: string;
+  name: string;
+  displayName: string;
+  bio?: string;
+  category?: string;
+  avatarUrl?: string | null;
+  bannerUrl?: string | null;
+  subscriberCount: number;
+  isSubscribed?: boolean;
+}
+
+export interface CreatorProfile extends Creator {
+  bio: string;
+  category: string;
+  recentPosts?: CreatorPostPreview[];
+}
+
+export interface Subscription {
+  id: string;
+  creatorId: string;
+  userId?: string;
+  createdAt?: string;
+}


### PR DESCRIPTION
Closes #19 

## Summary

Builds the public creator profile page at `/creators/[handle]`, giving fans a responsive pre-subscription view with creator identity, bio, subscriber count, category, subscribe CTA, and posts preview/placeholder support.


## Changes

- Added dynamic creator route with `generateMetadata` and 404 handling for unknown handles.
- Added `ProfileHeader` with stable banner/avatar layout, category badge, bio, handle, display name, and subscriber count.
- Added `SubscribeButton` behavior:
  - guests see a login CTA with redirect
  - logged-in fans can subscribe
  - creators viewing their own profile see a disabled “Your profile” state
- Added `lib/api/creators.ts` with API fetch support and mock fallback data.
- Added creator profile/subscription-related API types.
- Added focused Node tests for mock lookup, API URL fetch behavior, fallback behavior, and unknown handles.
- Added missing `react-hook-form` root dependency so existing auth forms typecheck correctly.

## Testing

- `node --test src/lib/api/creators.test.mjs`
- `tsc --noEmit`
- `next build`
- Smoke-tested:
  - `/creators/luna` returns `200`
  - `/creators/unknown-creator` returns `404`

## Results

<img width="1917" height="964" alt="Screenshot 2026-06-19 at 3 39 00 PM" src="https://github.com/user-attachments/assets/a8279a93-4477-4b5c-bba7-cf436b35a7e1" />


<img width="1917" height="964" alt="Screenshot 2026-06-19 at 3 39 07 PM" src="https://github.com/user-attachments/assets/82a2baa3-b85b-4525-b607-e805ab6cb9a2" />
