### PR TITLE
Scaffold creator dashboard page with stat cards and mock data

### DIFF
--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -1,7 +1,39 @@
+import DashboardHeader from "@/components/dashboard/DashboardHeader";
+import StatCard from "@/components/dashboard/StatCard";
+import { mockDashboardData } from "@/lib/mocks/dashboard";
+
 export default function DashboardPage() {
+  const { creatorName, profileComplete, stats } = mockDashboardData;
+
   return (
-    <main className="min-h-screen flex items-center justify-center p-8">
-      <h1 className="text-2xl font-semibold">Dashboard</h1>
-    </main>
+    <div className="space-y-8">
+      <DashboardHeader creatorName={creatorName} />
+
+      {profileComplete ? (
+        <section aria-labelledby="dashboard-stats-heading">
+          <h2 id="dashboard-stats-heading" className="sr-only">
+            Creator statistics
+          </h2>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {stats.map((stat) => (
+              <StatCard key={stat.label} stat={stat} />
+            ))}
+          </div>
+        </section>
+      ) : (
+        <section
+          aria-labelledby="dashboard-empty-heading"
+          className="flex flex-col items-center justify-center rounded-xl border border-dashed bg-muted/40 px-6 py-16 text-center"
+        >
+          <h2 id="dashboard-empty-heading" className="text-lg font-semibold">
+            Complete your profile to get started
+          </h2>
+          <p className="mt-2 max-w-md text-sm text-muted-foreground">
+            Add your bio, profile photo, and payout details to unlock your
+            creator dashboard stats.
+          </p>
+        </section>
+      )}
+    </div>
   );
 }

--- a/src/components/dashboard/DashboardHeader.tsx
+++ b/src/components/dashboard/DashboardHeader.tsx
@@ -1,0 +1,16 @@
+interface DashboardHeaderProps {
+  creatorName: string;
+}
+
+export default function DashboardHeader({ creatorName }: DashboardHeaderProps) {
+  return (
+    <header className="space-y-1">
+      <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">
+        Welcome back, {creatorName}
+      </h1>
+      <p className="text-sm text-muted-foreground">
+        Here&apos;s an overview of your creator activity.
+      </p>
+    </header>
+  );
+}

--- a/src/components/dashboard/StatCard.tsx
+++ b/src/components/dashboard/StatCard.tsx
@@ -1,0 +1,41 @@
+import { ArrowDown, ArrowUp, Minus } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { DashboardStat } from "@/lib/mocks/dashboard";
+
+interface StatCardProps {
+  stat: DashboardStat;
+}
+
+const trendIcons = {
+  up: ArrowUp,
+  down: ArrowDown,
+  neutral: Minus,
+} as const;
+
+const trendColors = {
+  up: "text-green-600 dark:text-green-400",
+  down: "text-red-600 dark:text-red-400",
+  neutral: "text-muted-foreground",
+} as const;
+
+export default function StatCard({ stat }: StatCardProps) {
+  const TrendIcon = stat.trend ? trendIcons[stat.trend.direction] : null;
+
+  return (
+    <article className="rounded-xl border bg-card p-5 text-card-foreground shadow-sm">
+      <p className="text-sm font-medium text-muted-foreground">{stat.label}</p>
+      <p className="mt-2 text-3xl font-semibold tracking-tight">{stat.value}</p>
+      {stat.trend && TrendIcon && (
+        <p
+          className={cn(
+            "mt-3 flex items-center gap-1 text-xs font-medium",
+            trendColors[stat.trend.direction],
+          )}
+        >
+          <TrendIcon className="h-3.5 w-3.5" aria-hidden="true" />
+          <span>{stat.trend.label}</span>
+        </p>
+      )}
+    </article>
+  );
+}

--- a/src/lib/mocks/dashboard.ts
+++ b/src/lib/mocks/dashboard.ts
@@ -1,0 +1,46 @@
+/**
+ * MOCK DATA — replace with real API hooks when backend is wired.
+ */
+
+export interface DashboardStat {
+  label: string;
+  value: string;
+  trend?: {
+    direction: "up" | "down" | "neutral";
+    label: string;
+  };
+}
+
+export interface DashboardMockData {
+  creatorName: string;
+  profileComplete: boolean;
+  stats: DashboardStat[];
+}
+
+export const mockDashboardData: DashboardMockData = {
+  creatorName: "Aria Sounds",
+  profileComplete: true,
+  stats: [
+    {
+      label: "Followers",
+      value: "12,400",
+      trend: { direction: "up", label: "+8.2% this month" },
+    },
+    {
+      label: "Earnings",
+      value: "$3,240",
+      trend: { direction: "up", label: "+12.5% this month" },
+    },
+    {
+      label: "Posts",
+      value: "48",
+      trend: { direction: "neutral", label: "3 published this week" },
+    },
+  ],
+};
+
+export const mockNewCreatorDashboardData: DashboardMockData = {
+  creatorName: "New Creator",
+  profileComplete: false,
+  stats: [],
+};


### PR DESCRIPTION
Add DashboardHeader and StatCard components, mock dashboard data, and a responsive stats grid with empty state for new creators.
close #7 